### PR TITLE
feat: Add option to disable line icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If your `tsconfig.json` is not at the project root, set the path in your VS Code
 ## Extension Settings
 
 - `nextjsComponentBoundaryVisualizer.tsconfigPath`: Path to `tsconfig.json` (absolute or workspace-relative). If empty, `<project root>/tsconfig.json` is used.
+- `nextjsComponentBoundaryVisualizer.enableLineIcon`: Enable/disable the icon at the beginning of the line. Defaults to true.
 
 ## Icons
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
           "type": "string",
           "default": "",
           "description": "Path to tsconfig.json (absolute or workspace-relative). If empty, <project root>/tsconfig.json is used."
+        },
+        "nextjsComponentBoundaryVisualizer.enableLineIcon": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the icon at the beginning of the line."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,13 @@ export function activate(context: vscode.ExtensionContext) {
 	if (graph) {
 		graph.build();
 		new ClientComponentStatusBar(context, graph);
-		new ClientComponentLineDecorator(context, graph);
+
+		// Instantiate the line decorator if enableLineIcon is true
+		const config = vscode.workspace.getConfiguration('nextjsComponentBoundaryVisualizer');
+		const enableLineIcon = config.get<boolean>('enableLineIcon');
+		if (enableLineIcon) {
+			new ClientComponentLineDecorator(context, graph);
+		}
 
 		// Update the graph only once on file save/create/delete (debounced)
 		const watcher = vscode.workspace.createFileSystemWatcher('**/*.{ts,tsx}');

--- a/src/ui/clientComponentLineDecorator/index.ts
+++ b/src/ui/clientComponentLineDecorator/index.ts
@@ -26,17 +26,15 @@ export class ClientComponentLineDecorator {
             this.decoration = undefined;
         }
         if (node && node.type === 'client') {
-            const config = vscode.workspace.getConfiguration('nextjsComponentBoundaryVisualizer');
-            const enableLineIcon = config.get<boolean>('enableLineIcon');
             this.decoration = vscode.window.createTextEditorDecorationType({
                 isWholeLine: true,
                 backgroundColor: 'rgba(128,0,128,0.08)', // light purple
-                before: enableLineIcon ? {
+                before: {
                     contentText: typeIcon.client,
                     color: '#a259ff',
                     margin: '0 8px 0 0',
                     fontWeight: 'bold',
-                } : undefined,
+                },
             });
             const selections = editor.selections.map(sel => ({
                 range: new vscode.Range(sel.start.line, 0, sel.start.line, 0),
@@ -44,17 +42,15 @@ export class ClientComponentLineDecorator {
             }));
             editor.setDecorations(this.decoration, selections);
         } else if (node && node.type === 'universal') {
-            const config = vscode.workspace.getConfiguration('nextjsComponentBoundaryVisualizer');
-            const enableLineIcon = config.get<boolean>('enableLineIcon');
             this.decoration = vscode.window.createTextEditorDecorationType({
                 isWholeLine: true,
                 backgroundColor: 'rgba(0, 120, 212, 0.08)', // light blue
-                before: enableLineIcon ? {
+                before: {
                     contentText: typeIcon.universal,
                     color: '#0078d4',
                     margin: '0 8px 0 0',
                     fontWeight: 'bold',
-                } : undefined,
+                },
             });
             const selections = editor.selections.map(sel => ({
                 range: new vscode.Range(sel.start.line, 0, sel.start.line, 0),

--- a/src/ui/clientComponentLineDecorator/index.ts
+++ b/src/ui/clientComponentLineDecorator/index.ts
@@ -26,15 +26,17 @@ export class ClientComponentLineDecorator {
             this.decoration = undefined;
         }
         if (node && node.type === 'client') {
+            const config = vscode.workspace.getConfiguration('nextjsComponentBoundaryVisualizer');
+            const enableLineIcon = config.get<boolean>('enableLineIcon');
             this.decoration = vscode.window.createTextEditorDecorationType({
                 isWholeLine: true,
                 backgroundColor: 'rgba(128,0,128,0.08)', // light purple
-                before: {
+                before: enableLineIcon ? {
                     contentText: typeIcon.client,
                     color: '#a259ff',
                     margin: '0 8px 0 0',
                     fontWeight: 'bold',
-                },
+                } : undefined,
             });
             const selections = editor.selections.map(sel => ({
                 range: new vscode.Range(sel.start.line, 0, sel.start.line, 0),
@@ -42,15 +44,17 @@ export class ClientComponentLineDecorator {
             }));
             editor.setDecorations(this.decoration, selections);
         } else if (node && node.type === 'universal') {
+            const config = vscode.workspace.getConfiguration('nextjsComponentBoundaryVisualizer');
+            const enableLineIcon = config.get<boolean>('enableLineIcon');
             this.decoration = vscode.window.createTextEditorDecorationType({
                 isWholeLine: true,
                 backgroundColor: 'rgba(0, 120, 212, 0.08)', // light blue
-                before: {
+                before: enableLineIcon ? {
                     contentText: typeIcon.universal,
                     color: '#0078d4',
                     margin: '0 8px 0 0',
                     fontWeight: 'bold',
-                },
+                } : undefined,
             });
             const selections = editor.selections.map(sel => ({
                 range: new vscode.Range(sel.start.line, 0, sel.start.line, 0),


### PR DESCRIPTION
Adds a new configuration option `nextjsComponentBoundaryVisualizer.enableLineIcon` to allow users to disable the line icons that indicate component types.

行頭アイコンがあると画像のようにインデントが崩れるので、これを無効にするオプションを追加しました
デフォルトで有効（従来通りアイコンが表示される）です
（vscodeの拡張を触ったのは初めてなので作法が変だったらすみません）

<img width="579" height="72" alt="Screenshot From 2025-07-18 17-32-42" src="https://github.com/user-attachments/assets/e22d4dc7-fa6d-49d0-9408-dc9a0429d722" />
