### PR TITLE
fix: silence initialization errors for non-Next.js projects

### DIFF
--- a/.changeset/fix-silent-error-non-nextjs.md
+++ b/.changeset/fix-silent-error-non-nextjs.md
@@ -1,0 +1,5 @@
+---
+"vscode-nextjs-component-boundary-visualizer": patch
+---
+
+Silently ignore initialization errors for non-Next.js projects. Errors are still shown when a `next.config.*` file is present.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,9 @@
-// biome-ignore lint/performance/noNamespaceImport: vscode cannot import with default import
-import * as vscode from "vscode";
 // biome-ignore lint/performance/noNamespaceImport: node:fs cannot import with default import
 import * as fs from "node:fs";
 // biome-ignore lint/performance/noNamespaceImport: node:path cannot import with default import
 import * as path from "node:path";
+// biome-ignore lint/performance/noNamespaceImport: vscode cannot import with default import
+import * as vscode from "vscode";
 import { resolveTsconfigPath } from "./core/resolveTsConfigFilePath/index.js";
 
 // This method is called when your extension is activated
@@ -74,11 +74,18 @@ async function initialize(
     );
     graph.onDidUpdate(() => decorationProvider.refresh());
   } catch (err) {
-    const hasNextConfig = ["next.config.js", "next.config.ts", "next.config.mjs", "next.config.cjs"]
-      .some((f) => fs.existsSync(path.join(workspaceRoot, f)));
+    const hasNextConfig = [
+      "next.config.js",
+      "next.config.ts",
+      "next.config.mjs",
+      "next.config.cjs",
+    ].some((f) => fs.existsSync(path.join(workspaceRoot, f)));
     if (hasNextConfig) {
-      const message = err instanceof Error ? err.message : "Initialization failed";
-      vscode.window.showErrorMessage(`Next.js Component Boundary Visualizer: ${message}`);
+      const message =
+        err instanceof Error ? err.message : "Initialization failed";
+      vscode.window.showErrorMessage(
+        `Next.js Component Boundary Visualizer: ${message}`
+      );
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,9 @@
 // biome-ignore lint/performance/noNamespaceImport: vscode cannot import with default import
 import * as vscode from "vscode";
+// biome-ignore lint/performance/noNamespaceImport: node:fs cannot import with default import
+import * as fs from "node:fs";
+// biome-ignore lint/performance/noNamespaceImport: node:path cannot import with default import
+import * as path from "node:path";
 import { resolveTsconfigPath } from "./core/resolveTsConfigFilePath/index.js";
 
 // This method is called when your extension is activated
@@ -70,11 +74,12 @@ async function initialize(
     );
     graph.onDidUpdate(() => decorationProvider.refresh());
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Initialization failed";
-    vscode.window.showErrorMessage(
-      `Next.js Component Boundary Visualizer: ${message}`
-    );
+    const hasNextConfig = ["next.config.js", "next.config.ts", "next.config.mjs", "next.config.cjs"]
+      .some((f) => fs.existsSync(path.join(workspaceRoot, f)));
+    if (hasNextConfig) {
+      const message = err instanceof Error ? err.message : "Initialization failed";
+      vscode.window.showErrorMessage(`Next.js Component Boundary Visualizer: ${message}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Non-Next.js projects containing `.tsx` files trigger this extension due to the `workspaceContains:**/*.tsx` activation event
- Previously, any initialization failure (e.g. missing `tsconfig.json`) showed an error notification to the user
- Error messages are now only shown when a `next.config.*` file is present, confirming it is a Next.js project — all other failures are silently ignored

## Test plan

- [ ] Open a non-Next.js project with `.tsx` files — confirm no error notification appears
- [ ] Open a Next.js project with `next.config.*` and a misconfiguration (e.g. invalid `tsconfigPath` setting) — confirm error notification still appears
- [ ] Open a normal Next.js project — confirm extension works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)